### PR TITLE
[Backend] Add `filetype` to the FileController#show response

### DIFF
--- a/api/app/controllers/files_controller.rb
+++ b/api/app/controllers/files_controller.rb
@@ -7,6 +7,7 @@ class FilesController < ApplicationController
 
     render(json: {
       filepath: source_file.filepath,
+      filetype: FileClassifier.new(source_file.filepath).filetype,
       commits_count: source_file.commits.count,
       main_contributor: source_file.main_contributor,
       line_count: source_file.line_count,

--- a/api/test/controllers/files_controller_test.rb
+++ b/api/test/controllers/files_controller_test.rb
@@ -26,6 +26,7 @@ class FilesControllerTest < ActionDispatch::IntegrationTest
 
     expected_response = {
       "filepath" => "main.rb",
+      "filetype" => "ruby",
       "commits_count" => source_file.commits.size,
       "main_contributor" => {
         "author" => "Jonathan Lalande",


### PR DESCRIPTION
Add the `filetype` to the response of the `FileController#show` action

![image](https://github.com/user-attachments/assets/a4366449-a020-426a-8845-4a3ce5b315d3)
