### PR TITLE
[Backend] Remove Gitland repository from disk when a Repository is destroyed. 

### DIFF
--- a/api/app/models/repository.rb
+++ b/api/app/models/repository.rb
@@ -8,6 +8,7 @@ class Repository < ApplicationRecord
   }
 
   after_create_commit { InitializeRepositoryJob.perform_later(repository_id: id) }
+  after_destroy_commit :remove_gitland_repository
 
   class << self
     def find_by_url(url)
@@ -32,5 +33,11 @@ class Repository < ApplicationRecord
       u.path = self.path
       u.scheme = "https"
     end.to_s
+  end
+
+  private
+
+  def remove_gitland_repository
+    Gitland::Repository.new(self).destroy
   end
 end

--- a/api/app/services/gitland/repository.rb
+++ b/api/app/services/gitland/repository.rb
@@ -12,6 +12,10 @@ module Gitland
       Commands::Log.new(@repository, format: format, first_parent: first_parent).execute { |logs| yield logs }
     end
 
+    def destroy
+      FileUtils.remove_dir(disk_path, force: true)
+    end
+
     def list_all_files_with_size
       sha_a = Commands::Diff::EMPTY_DIRECTORY_TREE_HASH
       sha_b = Commands::Diff::HEAD
@@ -41,6 +45,12 @@ module Gitland
         .first
 
       line.strip.split.first.to_i
+    end
+
+    private
+
+    def disk_path
+      Gitland::Storage.new(@repository).absolute_path
     end
   end
 end

--- a/api/test/models/repository_test.rb
+++ b/api/test/models/repository_test.rb
@@ -55,4 +55,14 @@ class RepositoryTest < ActiveSupport::TestCase
     repository = Repository.create(name: "react", domain: "github.com", path: "/facebook/react")
     assert_enqueued_with(job: InitializeRepositoryJob, args: [ { repository_id: repository.id } ])
   end
+
+  test "removes gitland repository when destroyed" do
+    repository = repositories(:rails)
+
+    gitland_repository_mock = mock()
+    gitland_repository_mock.expects(:destroy).once
+    Gitland::Repository.expects(:new).with(repository).returns(gitland_repository_mock)
+
+    repository.destroy!
+  end
 end

--- a/api/test/services/gitland/repository_test.rb
+++ b/api/test/services/gitland/repository_test.rb
@@ -55,5 +55,13 @@ module Gitland
 
       assert_equal(55, Gitland::Repository.new(@repository).file_line_count("api/Gemfile"))
     end
+
+    test "#destroy removes the repository from disk" do
+      FileUtils
+        .expects(:remove_dir)
+        .with(Gitland::Storage.new(@repository).absolute_path, force: true)
+
+      Gitland::Repository.new(@repository).destroy
+    end
   end
 end


### PR DESCRIPTION
Add a callback that will remove the local disk copy of the repository whenever a `Repository` gets destroyed.