### PR TITLE
[Backend]  Add #search endpoint on RepositoriesController

### DIFF
--- a/api/app/controllers/repositories_controller.rb
+++ b/api/app/controllers/repositories_controller.rb
@@ -5,6 +5,21 @@ class RepositoriesController < ApplicationController
     render(json: current_repository)
   end
 
+  def search
+    url = params.permit(:url).fetch(:url)
+
+    repository = Repository.find_by_url(url)
+    remote_repository = GithubService.new.fetch_remote_repository(url)
+
+    render(
+      json: {
+        repository: repository,
+        remote_repository: remote_repository
+      },
+      status: (repository || remote_repository) ? :ok : :not_found
+    )
+  end
+
   def create
     url = params.permit(:url).fetch(:url)
 

--- a/api/app/models/remote_repository.rb
+++ b/api/app/models/remote_repository.rb
@@ -20,4 +20,14 @@ class RemoteRepository
   def path
     @uri.path
   end
+
+  def as_json
+    {
+      name: name,
+      description: @description,
+      domain: domain,
+      path: path,
+      url: @uri.to_s
+    }
+  end
 end

--- a/api/app/models/repository.rb
+++ b/api/app/models/repository.rb
@@ -35,6 +35,18 @@ class Repository < ApplicationRecord
     end.to_s
   end
 
+  def as_json
+    {
+      id: id,
+      name: name,
+      domain: domain,
+      path: path,
+      url: remote_url,
+      created_at: created_at,
+      updated_at: updated_at
+    }
+  end
+
   private
 
   def remove_gitland_repository

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
      mount MissionControl::Jobs::Engine, at: "/jobs"
   end
 
+  get "/repositories/search", to: "repositories#search"
   get "/repositories/:repository_id", to: "repositories#show"
   post "/repositories", to: "repositories#create"
 

--- a/api/documentation/endpoints.md
+++ b/api/documentation/endpoints.md
@@ -4,6 +4,63 @@
 This project is a standard rails project. Therefore, you can get a good overview of all the endpoints by checking the [`config/routes.rb`](../config/routes.rb) file. You can learn about routing in rails here: https://guides.rubyonrails.org/routing.html
 
 ## Repositories
+### Search a repository via URL
+Retrieve data about a repository via a remote URL.
+Currently, only repositories from `https://github.com` are supported.
+
+Example request for a repository not yet analyzed by the application:
+```
+GET /repositories/search?url=https://github.com/moodle/moodle
+```
+
+Response:
+```json
+  "repository": null,
+  "remote_repository": {
+    "name": "moodle",
+    "description": "Moodle - the world's open source learning platform",
+    "domain": "github.com",
+    "path": "/moodle/moodle",
+    "url": "https://github.com/moodle/moodle"
+  }
+```
+
+Example request for a repository known by the application:
+```
+GET /repositories/search?url=https://github.com/moodle/moodle
+```
+
+Response:
+```json
+  "repository": {
+    "id": 12345,
+    "name": "moodle",
+    "domain": "github.com",
+    "path": "/moodle/moodle",
+    "url": "https://github.com/moodle/moodle",
+    "created_at": "2024-11-02 05:25:16.365778000 UTC +00:00",
+    "updated_at": "2024-11-02 05:25:16.365778000 UTC +00:00"
+  }
+  "remote_repository": {
+    "name": "moodle",
+    "description": "Moodle - the world's open source learning platform",
+    "domain": "github.com",
+    "path": "/moodle/moodle",
+    "url": "https://github.com/moodle/moodle"
+  }
+```
+
+Example request for a repository that does not exists:
+```
+GET /repositories/search?url=https://github.com/not-found/invalid
+```
+
+Response:
+```json
+  "repository": null,
+  "remote_repository": null
+```
+
 ### Show information about a repository
 Retrieve data about a repository.
 

--- a/api/test/controllers/repositories_controller_test.rb
+++ b/api/test/controllers/repositories_controller_test.rb
@@ -53,6 +53,102 @@ class RepositoriesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "#search returns 404 if the repository does not exists in our database and on the remote" do
+    stub_remote_repository(nil) do
+      get("/repositories/search?url=https://github.com/non-existing/repository", as: :json)
+
+      assert_response(:not_found)
+    end
+  end
+
+  test "#search returns 200 if the repository does not exists in our database, but exists on the remote" do
+    remote_repository = RemoteRepository.new(
+      name: "discourse",
+      description: "A platform for community discussion. Free, open, simple.",
+      url: "https://github.com/discourse/discourse"
+    )
+
+    stub_remote_repository(remote_repository) do
+      get("/repositories/search?url=https://github.com/discourse/discourse", as: :json)
+
+      assert_response(:ok)
+      assert_equal(
+        {
+          "repository" => nil,
+          "remote_repository" => {
+            "name" => "discourse",
+            "description" => "A platform for community discussion. Free, open, simple.",
+            "domain" => "github.com",
+            "path" => "/discourse/discourse",
+            "url" => "https://github.com/discourse/discourse"
+          }
+        },
+        response.parsed_body
+      )
+    end
+  end
+
+  test "#search returns 200 if the repository exists in our database, but not on the remote" do
+    repository = repositories(:moodle)
+
+    stub_remote_repository(nil) do
+      get("/repositories/search?url=#{repository.remote_url}", as: :json)
+
+      assert_response(:ok)
+      assert_equal(
+        {
+          "repository" => {
+            "id" => repository.id,
+            "name" => "moodle",
+            "domain" => "github.com",
+            "path" => "/moodle/moodle",
+            "url" => "https://github.com/moodle/moodle",
+            "created_at" => repository.created_at.as_json,
+            "updated_at" => repository.updated_at.as_json
+          },
+          "remote_repository" => nil
+        },
+        response.parsed_body
+      )
+    end
+  end
+
+  test "#search returns 200 if the repository exists in our database and on the remote" do
+    repository = repositories(:moodle)
+    remote_repository = RemoteRepository.new(
+      name: "moodle",
+      description: "Moodle - the world's open source learning platform",
+      url: "https://github.com/moodle/moodle"
+    )
+
+    stub_remote_repository(remote_repository) do
+      get("/repositories/search?url=#{repository.remote_url}", as: :json)
+
+      assert_response(:ok)
+      assert_equal(
+        {
+          "repository" => {
+            "id" => repository.id,
+            "name" => "moodle",
+            "domain" => "github.com",
+            "path" => "/moodle/moodle",
+            "url" => "https://github.com/moodle/moodle",
+            "created_at" => repository.created_at.as_json,
+            "updated_at" => repository.updated_at.as_json
+          },
+          "remote_repository" => {
+            "name" => "moodle",
+            "description" => "Moodle - the world's open source learning platform",
+            "domain" => "github.com",
+            "path" => "/moodle/moodle",
+            "url" => "https://github.com/moodle/moodle"
+          }
+        },
+        response.parsed_body
+      )
+    end
+  end
+
   private
 
   def stub_remote_repository(remote_repository)

--- a/api/test/models/remote_repository_test.rb
+++ b/api/test/models/remote_repository_test.rb
@@ -20,4 +20,17 @@ class RemoteRepositoryTest < ActiveSupport::TestCase
   test "#path" do
     assert_equal("/discourse/discourse", @remote_repository.path)
   end
+
+  test "#as_json" do
+    assert_equal(
+      {
+        name: "discourse",
+        description: "A platform for community discussion. Free, open, simple.",
+        domain: "github.com",
+        path: "/discourse/discourse",
+        url: "https://github.com/discourse/discourse"
+      },
+      @remote_repository.as_json
+    )
+  end
 end


### PR DESCRIPTION
Closes: https://github.com/visevol/Cscope/issues/11

The #search action searches a repository by remote url by checking if we have a record of the repository in our database, but also on the remote.