### PR TITLE
[Frontend] Update the `startProjectPage` in the frontend to search repositories by url

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -36,7 +36,7 @@ gem "thruster", require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
-# gem "rack-cors"
+gem "rack-cors"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -227,6 +227,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.7)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -340,6 +342,7 @@ DEPENDENCIES
   mocha
   octokit
   puma (>= 5.0)
+  rack-cors
   rails!
   rubocop-rails-omakase
   solid_cable

--- a/api/config/initializers/cors.rb
+++ b/api/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "*"
+
+    resource "*",
+      headers: :any,
+      methods: [ :get, :post, :put, :patch, :delete, :options, :head ]
+  end
+end

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:3000

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "antd": "^5.21.6",
+        "axios": "^1.7.7",
         "node-sass": "^7.0.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -5432,6 +5433,29 @@
       "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14981,6 +15005,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=4000 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "antd": "^5.21.6",
+    "axios": "^1.7.7",
     "node-sass": "^7.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,0 +1,6 @@
+import axios from "axios";
+
+axios.defaults.baseURL = process.env.REACT_APP_API_URL
+axios.defaults.validateStatus = code => code < 500;
+
+export * from "./repositories"

--- a/frontend/src/api/repositories.ts
+++ b/frontend/src/api/repositories.ts
@@ -1,0 +1,40 @@
+import axios from "axios";
+import Repository from "models/repository";
+import RemoteRepository from "models/remoteRepository";
+
+interface RepositorySearchResult {
+  repository: Repository | null;
+  remoteRepository: RemoteRepository | null;
+}
+
+export async function searchRepositoryByUrl(url: string): Promise<RepositorySearchResult> {
+  const response = await axios.get('/repositories/search', { params: {url: url} });
+  const result: RepositorySearchResult = {
+    repository: null,
+    remoteRepository: null,
+  }
+
+  if (response.data.repository) {
+    result.repository = {
+      id: response.data.repository.id,
+      name: response.data.repository.name,
+      domain: response.data.repository.domain,
+      path: response.data.repository.path,
+      url: response.data.repository.url,
+      createdAt: response.data.repository.created_at,
+      updatedAt: response.data.repository.updated_at,
+    }
+  }
+
+  if (response.data.remote_repository) {
+    result.remoteRepository = {
+      name: response.data.remote_repository.name,
+      description: response.data.remote_repository.description,
+      domain: response.data.remote_repository.domain,
+      path: response.data.remote_repository.path,
+      url: response.data.remote_repository.url,
+    }
+  }
+
+  return result
+}

--- a/frontend/src/components/AddRepository.tsx
+++ b/frontend/src/components/AddRepository.tsx
@@ -3,13 +3,27 @@ import "assets/styles/addRepository.scss";
 import { Input } from "antd";
 import { useNavigate } from "react-router-dom";
 
+import { searchRepositoryByUrl } from "api";
+
 const AddRepository: React.FC = () => {
-  const [repositoryId, setRepositoryId] = useState<number>(1728710481833);
+  const [url, setUrl] = useState<string>("");
   const navigate = useNavigate();
 
-  const handleEnterPress = () => {
-    navigate(`/repository/${repositoryId}/change-volume`);
+  const handleEnterPress = async () => {
+    const result = await searchRepositoryByUrl(url);
+
+    if (result.repository) {
+      return navigate(`/repository/${result.repository.id}/change-volume`);
+    }
+
+    if (result.remoteRepository) {
+      console.log(result.remoteRepository)
+      alert(`repository: ${result.remoteRepository.url} exists, but not yet analyzed.`)
+    } else {
+      alert(`repository: ${url} does not exists.`)
+    }
   };
+
   return (
     <div className="cscope">
       <h1 className="cscope__title">CScope</h1>
@@ -17,8 +31,10 @@ const AddRepository: React.FC = () => {
       <div className="cscope__search">
         <Input
           className="cscope__input"
+          value={url}
           placeholder="Insert URL and press enter"
           onPressEnter={handleEnterPress}
+          onChange={e => setUrl(e.target.value)}
         />
       </div>
     </div>

--- a/frontend/src/models/remoteRepository.ts
+++ b/frontend/src/models/remoteRepository.ts
@@ -1,0 +1,7 @@
+export default interface RemoteRepository {
+  name: string;
+  description: string;
+  domain: string;
+  path: string;
+  url: string;
+}

--- a/frontend/src/models/repository.ts
+++ b/frontend/src/models/repository.ts
@@ -1,0 +1,9 @@
+export default interface Repository {
+  id: number;
+  name: string;
+  domain: string;
+  path: string;
+  url: string;
+  createdAt: Date;
+  updatedAt: Date;
+}


### PR DESCRIPTION
Closes: https://github.com/visevol/Cscope/issues/90

**NOTE** This PR is based on top of https://github.com/visevol/Cscope/pull/92. Make sure to merge that PR first.

Update AddRepository component

Change the form action in AddRepository.tsx to make a request to the
repository search API endpoint.

If the repository exists in our database, we navigate to
`/repository/:repository_id/change-volume`.

If the repository exists on the remote, but not in our database, we show
an alert to the user that the repository exists, but not yet analyzed.

If the repository does not exists anywhere, we just mention that to the
user.

---

Both the API and the create-react-app dev server runs on port 3000. So I also changed the port of the react dev server to 4000 to avoid conflicts.