### PR TITLE
added route for bubble chart data

### DIFF
--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -6,4 +6,16 @@ class ApplicationController < ActionController::API
   def render_repository_not_found
     render(json: { message: "repository does not exists." }, status: :not_found)
   end
+
+  def start_date_filter
+    DateTime.parse(params[:start_date])
+  rescue
+    nil
+  end
+
+  def end_date_filter
+    DateTime.parse(params[:end_date])
+  rescue
+    nil
+  end
 end

--- a/api/app/controllers/commits_controller.rb
+++ b/api/app/controllers/commits_controller.rb
@@ -17,36 +17,4 @@ class CommitsController < ApplicationController
 
     render(json: stats)
   end
-
-  def files_over_time
-    return render_repository_not_found unless current_repository
-
-    stats = RepositoryStatisticsService
-      .new(current_repository)
-      .file_modifications_by_date(start_date: start_date_filter, end_date: end_date_filter)
-      .map! do |filepath, total_additions, total_deletions, total_modifications|
-        {
-          filepath: filepath,
-          total_additions: total_additions,
-          total_deletions: total_deletions,
-          total_modifications: total_modifications
-        }
-      end
-
-    render(json: stats)
-  end
-
-  private
-
-  def start_date_filter
-    DateTime.parse(params[:start_date])
-  rescue
-    nil
-  end
-
-  def end_date_filter
-    DateTime.parse(params[:end_date])
-  rescue
-    nil
-  end
 end

--- a/api/app/controllers/commits_controller.rb
+++ b/api/app/controllers/commits_controller.rb
@@ -18,6 +18,24 @@ class CommitsController < ApplicationController
     render(json: stats)
   end
 
+  def files_over_time
+    return render_repository_not_found unless current_repository
+
+    stats = RepositoryStatisticsService
+      .new(current_repository)
+      .file_modifications_by_date(start_date: start_date_filter, end_date: end_date_filter)
+      .map! do |filepath, total_additions, total_deletions, total_modifications|
+        {
+          filepath: filepath,
+          total_additions: total_additions,
+          total_deletions: total_deletions,
+          total_modifications: total_modifications
+        }
+      end
+
+    render(json: stats)
+  end
+
   private
 
   def start_date_filter

--- a/api/app/controllers/files_controller.rb
+++ b/api/app/controllers/files_controller.rb
@@ -26,6 +26,24 @@ class FilesController < ApplicationController
     render(json: data)
   end
 
+  def files_over_time
+    return render_repository_not_found unless current_repository
+
+    stats = RepositoryStatisticsService
+      .new(current_repository)
+      .file_modifications_by_date(start_date: start_date_filter, end_date: end_date_filter)
+      .map! do |filepath, total_additions, total_deletions, total_modifications|
+        {
+          filepath: filepath,
+          total_additions: total_additions,
+          total_deletions: total_deletions,
+          total_modifications: total_modifications
+        }
+      end
+
+    render(json: stats)
+  end
+
   private
 
   def render_source_file_not_found

--- a/api/app/services/repository_statistics_service.rb
+++ b/api/app/services/repository_statistics_service.rb
@@ -62,7 +62,6 @@ class RepositoryStatisticsService
     scope = scope.where(committer_date: start_date..) if start_date
     scope = scope.where(committer_date: ..end_date) if end_date
     scope
-      .joins(:source_file_changes)
       .joins(:source_files)
       .group("source_files.filepath")
       .pluck(

--- a/api/app/services/repository_statistics_service.rb
+++ b/api/app/services/repository_statistics_service.rb
@@ -56,4 +56,20 @@ class RepositoryStatisticsService
         Arel.sql("MIN(source_file_changes.category)")
       )
   end
+
+  def file_modifications_by_date(start_date: nil, end_date: nil)
+    scope = @repository.commits.on_changes_ledger
+    scope = scope.where(committer_date: start_date..) if start_date
+    scope = scope.where(committer_date: ..end_date) if end_date
+    scope
+      .joins(:source_file_changes)
+      .joins(:source_files)
+      .group('source_files.filepath')
+      .pluck(
+        Arel.sql('source_files.filepath'),
+        Arel.sql('SUM(source_file_changes.additions)'),
+        Arel.sql('SUM(source_file_changes.deletions)'),
+        Arel.sql('SUM(source_file_changes.additions + source_file_changes.deletions)')
+      )
+  end
 end

--- a/api/app/services/repository_statistics_service.rb
+++ b/api/app/services/repository_statistics_service.rb
@@ -64,12 +64,12 @@ class RepositoryStatisticsService
     scope
       .joins(:source_file_changes)
       .joins(:source_files)
-      .group('source_files.filepath')
+      .group("source_files.filepath")
       .pluck(
-        Arel.sql('source_files.filepath'),
-        Arel.sql('SUM(source_file_changes.additions)'),
-        Arel.sql('SUM(source_file_changes.deletions)'),
-        Arel.sql('SUM(source_file_changes.additions + source_file_changes.deletions)')
+        Arel.sql("source_files.filepath"),
+        Arel.sql("SUM(source_file_changes.additions)"),
+        Arel.sql("SUM(source_file_changes.deletions)"),
+        Arel.sql("SUM(source_file_changes.additions + source_file_changes.deletions)")
       )
   end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -20,5 +20,5 @@ Rails.application.routes.draw do
   get "/repositories/:repository_id/files/stats/change-history", to: "files#change_history"
 
   get "/repositories/:repository_id/commits/stats/commits_over_time", to: "commits#commits_over_time"
-  get "/repositories/:repository_id/commits/stats/files_over_time", to: "commits#files_over_time"
+  get "/repositories/:repository_id/files/stats/files_over_time", to: "files#files_over_time"
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -20,4 +20,5 @@ Rails.application.routes.draw do
   get "/repositories/:repository_id/files/stats/change-history", to: "files#change_history"
 
   get "/repositories/:repository_id/commits/stats/commits_over_time", to: "commits#commits_over_time"
+  get "/repositories/:repository_id/commits/stats/files_over_time", to: "commits#files_over_time"
 end

--- a/api/test/controllers/files_controller_test.rb
+++ b/api/test/controllers/files_controller_test.rb
@@ -47,6 +47,12 @@ class FilesControllerTest < ActionDispatch::IntegrationTest
     assert_response(:not_found)
   end
 
+  test "#files_over_time returns 404 when the repository does not exist" do
+    get "/repositories/9999999999/files/stats/files_over_time"
+
+    assert_response(:not_found)
+  end
+
   test "#change_history returns 200 when the repository exists" do
     get "/repositories/#{@repository.id}/files/stats/change-history"
 
@@ -82,5 +88,62 @@ class FilesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response(:ok)
     assert_equal(expected_response, response.parsed_body)
+  end
+
+  test "#files_over_time returns 200 if the repository exists" do
+    get "/repositories/#{@repository.id}/files/stats/files_over_time"
+
+    assert_response(:ok)
+    assert_equal(
+      [
+        {
+          "filepath" => "README.md",
+          "total_additions" => 9,
+          "total_deletions" => 0,
+          "total_modifications" => 9
+        },
+        {
+          "filepath" => "main.rb",
+          "total_additions" => 1,
+          "total_deletions" => 0,
+          "total_modifications" => 1
+        }
+      ],
+      response.parsed_body
+    )
+  end
+
+  test "#files_over_time output is filtered by `start_date` parameter" do
+    get "/repositories/#{@repository.id}/files/stats/files_over_time?start_date=2024-10-15"
+
+    assert_response(:ok)
+    assert_equal(
+      [
+        {
+          "filepath" => "README.md",
+          "total_additions" => 2,
+          "total_deletions" => 0,
+          "total_modifications" => 2
+        }
+      ],
+      response.parsed_body
+    )
+  end
+
+  test "#files_over_time output is filtered by `end_date` parameter" do
+    get "/repositories/#{@repository.id}/files/stats/files_over_time?end_date=2024-10-14"
+
+    assert_response(:ok)
+    assert_equal(
+      [
+        {
+          "filepath" => "README.md",
+          "total_additions" => 7,
+          "total_deletions" => 0,
+          "total_modifications" => 7
+        }
+      ],
+      response.parsed_body
+    )
   end
 end

--- a/api/test/controllers/files_controller_test.rb
+++ b/api/test/controllers/files_controller_test.rb
@@ -114,7 +114,7 @@ class FilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#files_over_time output is filtered by `start_date` parameter" do
-    get "/repositories/#{@repository.id}/files/stats/files_over_time?start_date=2024-10-15"
+    get "/repositories/#{@repository.id}/files/stats/files_over_time?start_date=2024-10-14"
 
     assert_response(:ok)
     assert_equal(
@@ -124,6 +124,12 @@ class FilesControllerTest < ActionDispatch::IntegrationTest
           "total_additions" => 2,
           "total_deletions" => 0,
           "total_modifications" => 2
+        },
+        {
+          "filepath" => "main.rb",
+          "total_additions" => 1,
+          "total_deletions" => 0,
+          "total_modifications" => 1
         }
       ],
       response.parsed_body


### PR DESCRIPTION
added the data in this format to keep naming consistency:
```
export interface FileModified {
  filepath: string;
  total_additions: number;
  total_deletions: number;
  total_modifications: number;
}
```

It can take a while to compute this information for the entire timeline of the repository (like 30 seconds which is pretty quick for that magnitude of information), else just specify a start_date and/or an end_date.

An interesting thing to note is the filepath shows when a file is renamed/moved to another directory which can be very useful for the other chart.
![image](https://github.com/user-attachments/assets/9d1bd397-3254-4293-a046-9b5ce7820cc6)
