### PR TITLE
[Backend] Add `last_synced_at` column on repositories

### DIFF
--- a/api/app/models/repository.rb
+++ b/api/app/models/repository.rb
@@ -43,7 +43,8 @@ class Repository < ApplicationRecord
       path: path,
       url: remote_url,
       created_at: created_at,
-      updated_at: updated_at
+      updated_at: updated_at,
+      last_synced_at: last_synced_at
     }
   end
 

--- a/api/app/services/repository_sync_service.rb
+++ b/api/app/services/repository_sync_service.rb
@@ -6,8 +6,12 @@ class RepositorySyncService
   def index
     gitland_repository = Gitland::Repository.new(@repository)
 
-    extract_full_commit_history(gitland_repository)
-    extract_commit_history_for_changes_ledger(gitland_repository)
+    @repository.transaction do
+      extract_full_commit_history(gitland_repository)
+      extract_commit_history_for_changes_ledger(gitland_repository)
+
+      @repository.update!(last_synced_at: DateTime.current)
+    end
   end
 
   private

--- a/api/db/migrate/20241127042936_add_last_sync_at_on_repositories.rb
+++ b/api/db/migrate/20241127042936_add_last_sync_at_on_repositories.rb
@@ -1,0 +1,5 @@
+class AddLastSyncAtOnRepositories < ActiveRecord::Migration[8.0]
+  def change
+    add_column :repositories, :last_synced_at, :datetime, default: nil
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -30,14 +30,15 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_01_002654) do
     t.string "path"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "last_synced_at"
     t.index ["domain", "path"], name: "index_repositories_on_domain_and_path", unique: true
   end
 
   create_table "source_file_changes", force: :cascade do |t|
     t.integer "commit_id"
-    t.integer "source_file_id"
     t.integer "additions", default: 0
     t.integer "deletions", default: 0
+    t.integer "source_file_id"
     t.string "category"
     t.index ["commit_id"], name: "index_source_file_changes_on_commit_id"
     t.index ["source_file_id", "commit_id"], name: "index_source_file_changes_on_source_file_id_and_commit_id", unique: true

--- a/api/test/controllers/repositories_controller_test.rb
+++ b/api/test/controllers/repositories_controller_test.rb
@@ -14,9 +14,19 @@ class RepositoriesControllerTest < ActionDispatch::IntegrationTest
     get "/repositories/#{repository.id}"
 
     assert_response(:ok)
-    assert_equal("rails", response.parsed_body[:name])
-    assert_equal("github.com", response.parsed_body[:domain])
-    assert_equal("/rails/rails", response.parsed_body[:path])
+    assert_equal(
+      {
+        "id" => repository.id,
+        "name" => "rails",
+        "domain" => "github.com",
+        "path" => "/rails/rails",
+        "url" => "https://github.com/rails/rails",
+        "created_at" => repository.created_at.as_json,
+        "updated_at" => repository.updated_at.as_json,
+        "last_synced_at" => nil
+      },
+      response.parsed_body
+    )
   end
 
   test "#create returns 200 if the repository already exists" do
@@ -104,7 +114,8 @@ class RepositoriesControllerTest < ActionDispatch::IntegrationTest
             "path" => "/moodle/moodle",
             "url" => "https://github.com/moodle/moodle",
             "created_at" => repository.created_at.as_json,
-            "updated_at" => repository.updated_at.as_json
+            "updated_at" => repository.updated_at.as_json,
+            "last_synced_at" => nil
           },
           "remote_repository" => nil
         },
@@ -134,7 +145,8 @@ class RepositoriesControllerTest < ActionDispatch::IntegrationTest
             "path" => "/moodle/moodle",
             "url" => "https://github.com/moodle/moodle",
             "created_at" => repository.created_at.as_json,
-            "updated_at" => repository.updated_at.as_json
+            "updated_at" => repository.updated_at.as_json,
+            "last_synced_at" => nil
           },
           "remote_repository" => {
             "name" => "moodle",

--- a/api/test/services/repository_sync_service_test.rb
+++ b/api/test/services/repository_sync_service_test.rb
@@ -316,6 +316,16 @@ class RepositorySyncServiceTest < ActiveSupport::TestCase
     assert_equal("create", space_file_b.source_file_changes.first.category)
   end
 
+  test "#index sets the last_synced_at column on the repository once it completes" do
+    freeze_time do
+      assert_nil(@repository.last_synced_at)
+
+      RepositorySyncService.new(@repository).index
+
+      assert_equal(DateTime.current, @repository.last_synced_at)
+    end
+  end
+
   private
 
   def stub_git_commit_history(&block)


### PR DESCRIPTION
# Description
Add a `last_synced_at` column on repositories. This column can be used to indicate the frontend when is the last time a repository was successfully synced. 

I'm also adding this field in the response of `GET /repositories/:id/` endpoint. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
