### PR TITLE
[Backend] Add endpoint to return the list of file types known in the repository

### DIFF
--- a/api/app/controllers/files_controller.rb
+++ b/api/app/controllers/files_controller.rb
@@ -44,21 +44,15 @@ class FilesController < ApplicationController
     render(json: stats)
   end
 
+  def file_types
+    return render_repository_not_found unless current_repository
+
+    render(json: current_repository.source_files.distinct.pluck(:filetype))
+  end
+
   private
 
   def render_source_file_not_found
     render(json: { message: "file does not exists." }, status: :not_found)
-  end
-
-  def start_date_filter
-    DateTime.parse(params[:start_date])
-  rescue
-    nil
-  end
-
-  def end_date_filter
-    DateTime.parse(params[:end_date])
-  rescue
-    nil
   end
 end

--- a/api/app/services/repository_sync_service.rb
+++ b/api/app/services/repository_sync_service.rb
@@ -154,7 +154,14 @@ class RepositorySyncService
   end
 
   def commit_batch_for_changes_ledger(batch)
-    @repository.source_files.insert_all(batch.filepaths.map { { filepath: _1, filetype: FileClassifier.new(_1).filetype } })
+    source_files = batch.filepaths.map do |filepath|
+      {
+        filepath: filepath,
+        filetype: FileClassifier.new(filepath).filetype
+      }
+    end
+
+    @repository.source_files.insert_all(source_files)
 
     commit_scope = @repository.commits.where(commit_hash: batch.commits.map { _1[:commit_hash] })
     commit_scope.update_all(for_changes_ledger: true)

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -18,7 +18,8 @@ Rails.application.routes.draw do
 
   get "/repositories/:repository_id/files/head/*filepath", to: "files#show", format: false
   get "/repositories/:repository_id/files/stats/change-history", to: "files#change_history"
+  get "/repositories/:repository_id/files/stats/files_over_time", to: "files#files_over_time"
+  get "/repositories/:repository_id/files/stats/file_types", to: "files#file_types"
 
   get "/repositories/:repository_id/commits/stats/commits_over_time", to: "commits#commits_over_time"
-  get "/repositories/:repository_id/files/stats/files_over_time", to: "files#files_over_time"
 end

--- a/api/lib/file_classifier.rb
+++ b/api/lib/file_classifier.rb
@@ -1,34 +1,116 @@
+# frozen_string_literal: true
+
 class FileClassifier
   def initialize(filepath)
     @filepath = filepath
   end
 
   FILE_TYPE_EXTENSIONS = {
+    ".a" => "static library",
+    ".asm" => "assembly",
+    ".bash" => "bash script",
+    ".bat" => "batch script",
     ".c" => "c",
     ".cc" => "c++",
+    ".conf" => "configuration file",
     ".cpp" => "c++",
+    ".cs" => "c#",
+    ".css" => "css",
+    ".csv" => "csv",
+    ".dart" => "dart",
+    ".db" => "database file",
+    ".dll" => "dynamic link library",
+    ".ear" => "enterprise archive",
+    ".exe" => "executable",
     ".go" => "go",
     ".h" => "header file",
+    ".hpp" => "c++ header file",
     ".hs" => "haskell",
+    ".htm" => "html",
+    ".html" => "html",
+    ".ini" => "configuration file",
+    ".ipynb" => "jupyter notebook",
+    ".jar" => "java archive",
     ".java" => "java",
+    ".jl" => "julia",
     ".js" => "javascript",
     ".json" => "json",
+    ".jsx" => "javascript (React)",
+    ".kt" => "kotlin",
+    ".less" => "less",
     ".lhs" => "haskell",
     ".lock" => "lock file",
+    ".log" => "log file",
     ".lua" => "lua",
+    ".m" => "objective-c",
     ".md" => "markdown",
+    ".mm" => "objective-c++",
+    ".o" => "object file",
+    ".php" => "php",
+    ".pl" => "perl",
+    ".ps1" => "powershell script",
     ".py" => "python",
+    ".r" => "r",
     ".rb" => "ruby",
     ".rs" => "rust",
+    ".scala" => "scala",
+    ".scss" => "sass",
+    ".sh" => "shell script",
+    ".so" => "shared object",
+    ".sql" => "sql",
+    ".swift" => "swift",
     ".toml" => "toml",
-    ".txt" => "plain text"
+    ".ts" => "typescript",
+    ".tsv" => "tsv",
+    ".tsx" => "typescript (React)",
+    ".txt" => "plain text",
+    ".vb" => "visual basic",
+    ".vbs" => "vbscript",
+    ".war" => "web archive",
+    ".xml" => "xml",
+    ".yaml" => "yaml",
+    ".yml" => "yaml"
   }.freeze
 
+  COMMON_KNOWN_FILES = {
+    ".env" => ".env",
+    ".eslintrc" => "eslint configuration",
+    ".gitignore" => "gitignore",
+    ".prettierrc" => "prettier configuration",
+    "Cargo.lock" => "rust lock file",
+    "Cargo.toml" => "rust package configuration",
+    "Dockerfile" => "Dockerfile",
+    "Gemfile" => "ruby dependencies",
+    "Gemfile.lock" => "ruby lock file",
+    "LICENSE" => "license file",
+    "LICENSE.md" => "markdown license file",
+    "LICENSE.txt" => "plain text license file",
+    "Makefile" => "build script",
+    "Pipfile" => "python package configuration",
+    "README" => "documentation",
+    "README.md" => "documentation",
+    "README.txt" => "documentation",
+    "build.gradle" => "gradle build script",
+    "compose.yml" => "Docker compose file",
+    "composer.json" => "php package configuration",
+    "composer.lock" => "php lock file",
+    "docker-compose.yml" => "Docker compose file",
+    "package.json" => "node.js package configuration",
+    "pom.xml" => "maven build configuration",
+    "requirements.txt" => "python dependencies"
+  }.freeze
+
+  UNKNOWN_FILE_TYPE = "unknown"
+
   def filetype
-    FILE_TYPE_EXTENSIONS.fetch(extension, "unknown")
+    COMMON_KNOWN_FILES[basename] || FILE_TYPE_EXTENSIONS[extension] || UNKNOWN_FILE_TYPE
   end
 
   def extension
     File.extname(@filepath)
+  end
+
+  def basename
+    File.basename(@filepath)
   end
 end

--- a/api/test/controllers/files_controller_test.rb
+++ b/api/test/controllers/files_controller_test.rb
@@ -152,4 +152,17 @@ class FilesControllerTest < ActionDispatch::IntegrationTest
       response.parsed_body
     )
   end
+
+  test "#file_types returns 404 when the repository does not exists" do
+    get "/repositories/9999999999/files/stats/file_types"
+
+    assert_response(:not_found)
+  end
+
+  test "#file_extensions returns the list of file types present in the repository" do
+    get "/repositories/#{@repository.id}/files/stats/file_types"
+
+    assert_response(:ok)
+    assert_equal([ "markdown", "ruby" ], response.parsed_body)
+  end
 end

--- a/api/test/lib/file_classifier_test.rb
+++ b/api/test/lib/file_classifier_test.rb
@@ -28,4 +28,11 @@ class FileClassifierTest < ActiveSupport::TestCase
   test "#filetype returns unknown for unknown filetype" do
     assert_equal("unknown", FileClassifier.new("src/main.xqc").filetype)
   end
+
+  test "#filetype returns filetype for commonly known filenames" do
+    assert_equal("Dockerfile", FileClassifier.new("Dockerfile").filetype)
+    assert_equal("Dockerfile", FileClassifier.new("src/Dockerfile").filetype)
+    assert_equal("Docker compose file", FileClassifier.new("docker-compose.yml").filetype)
+    assert_equal("Docker compose file", FileClassifier.new("src/docker-compose.yml").filetype)
+  end
 end


### PR DESCRIPTION
# Description
Add route that returns the file types in the repo

Add a new route that returns the list of file types present on the
repository:

```
GET /repositories/123/files/stats/file_types

[
  "ruby",
  "typescript",
  "markdown",
  "yaml",
  ...
]
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
