### PR TITLE
[Backend] Fix bug in RepositorySyncService

### DIFF
--- a/api/app/services/gitland/commands/log.rb
+++ b/api/app/services/gitland/commands/log.rb
@@ -18,9 +18,9 @@ module Gitland
       #     end
       #   end
       #
-      def initialize(repository, commit_hash: nil, format: nil, first_parent: false)
+      def initialize(repository, from: nil, format: nil, first_parent: false)
         @repository = repository
-        @commit_hash = commit_hash
+        @from = from
         @format = format
         @first_parent = first_parent
       end
@@ -31,13 +31,13 @@ module Gitland
         cli = Git::CommandLine.new({}, "/usr/bin/git", [], Logger.new("/dev/null"))
 
         command = [ "log" ]
-        command << "#{@commit_hash}..HEAD" if @commit_hash
         command << "--reverse"
         command << "--no-renames"
         command << "--numstat"
         command << "--summary"
         command << "--first-parent" if @first_parent
         command << "--pretty=format:#{@format}" if @format
+        command << "#{@from}..HEAD" if @from
 
         Tempfile.create(binmode: true) do |f|
           cli.run(

--- a/api/app/services/gitland/repository.rb
+++ b/api/app/services/gitland/repository.rb
@@ -12,8 +12,8 @@ module Gitland
       Commands::Pull.new(@repository).execute
     end
 
-    def log(latest_commit_hash: nil, format: nil, first_parent: false)
-      Commands::Log.new(@repository, commit_hash: latest_commit_hash, format: format, first_parent: first_parent).execute { |logs| yield logs }
+    def log(from: nil, format: nil, first_parent: false)
+      Commands::Log.new(@repository, from: from, format: format, first_parent: first_parent).execute { |logs| yield logs }
     end
 
     def destroy


### PR DESCRIPTION
# Description
Fix a bug where the ledger commits were not extracted during sync.

The sync service runs in two steps:
1. it extracts all commits in the history
2. it extracts "ledger" commits, commits as they appear on the "main"
   branch of the repository.

In https://github.com/visevol/Cscope/pull/73, we introduced the concept
of "last known commit" in the RepositorySyncService. The idea is to
start the extraction process from the latest commit in the database.

The bug is that the "last know commit" is fetched in both steps.

On the first step, the last known commit is accurate. For new
repositories, we don't have any commits in our database, so the
`git log` command extracts all commits, and we store this in the
database.

On the second step, the last known commit is fetched again from the database. It exists because it was written on the step just before. In this step, `git log` returns nothing because we're
essentially calling `git log HEAD..HEAD`.

